### PR TITLE
Implement hash-based packet routing with dummy audio systems

### DIFF
--- a/src/app/DummyAudioTester.cpp
+++ b/src/app/DummyAudioTester.cpp
@@ -1,0 +1,48 @@
+#include "../core/Program.h"
+#include "../ecs/GraphSystem.h"
+#include "../ecs/DummyAudioOut.h"
+#include "../ecs/DummyAudioIn.h"
+#include <chrono>
+#include <thread>
+
+using namespace core;
+using namespace ecs;
+
+class DummyAudioTester : public Program {
+public:
+    DummyAudioTester() : out(graph) {
+        graph.addSystem(&out);
+        graph.addSystem(&in);
+    }
+
+    bool init() override {
+        out.setTarget(in.address());
+        addSystem(&out);
+        addSystem(&in);
+        addSystem(&graph);
+        return true;
+    }
+
+    int run() {
+        if (!init()) return -1;
+        auto start = std::chrono::steady_clock::now();
+        while (std::chrono::steady_clock::now() - start < std::chrono::seconds(5)) {
+            update();
+            for (auto* sys : m_systems) sys->update();
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(23));
+        }
+        shutdown();
+        return 0;
+    }
+
+private:
+    GraphSystem graph;
+    DummyAudioOut out;
+    DummyAudioIn in;
+};
+
+int main() {
+    DummyAudioTester app;
+    return app.run();
+}

--- a/src/core/Hash.h
+++ b/src/core/Hash.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <cstddef>
+
+using hash_t = std::size_t;
+

--- a/src/ecs/DummyAudioIn.h
+++ b/src/ecs/DummyAudioIn.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "EcsSystem.h"
+#include <iostream>
+
+namespace ecs {
+
+class DummyAudioIn : public EcsSystem {
+public:
+    std::string name() const override { return "DummyAudioIn"; }
+    void update() override {}
+    void onPacket(graph::Packet& pkt) override {
+        auto& a = pkt.data.audio;
+        std::cout << "DummyAudioIn packet seq " << a.seq
+                  << " samples: " << a.samples[0] << ", " << a.samples[1]
+                  << ", " << a.samples[2] << ", " << a.samples[3] << std::endl;
+        pkt.address = 0; // delivered
+    }
+};
+
+} // namespace ecs

--- a/src/ecs/DummyAudioOut.cpp
+++ b/src/ecs/DummyAudioOut.cpp
@@ -1,0 +1,23 @@
+#include "DummyAudioOut.h"
+#include "../graph/PacketRecycler.h"
+#include <cstring>
+
+namespace ecs {
+
+void DummyAudioOut::update() {
+    graph::Packet* pkt = graph::PacketRecycler::instance().acquire();
+    pkt->format = graph::PacketFormat::Audio;
+    pkt->address = m_target;
+    auto& a = pkt->data.audio;
+    pkt->ptr = a.samples;
+    a.sampleRate = 44100;
+    a.channels = 2;
+    a.frames = 1024;
+    a.seq = m_seq++;
+    for (size_t i = 0; i < graph::AUDIO_SAMPLES_PER_PACKET; ++i) {
+        a.samples[i] = static_cast<float>(i % 4);
+    }
+    m_graph.enqueue(pkt);
+}
+
+} // namespace ecs

--- a/src/ecs/DummyAudioOut.h
+++ b/src/ecs/DummyAudioOut.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "EcsSystem.h"
+#include "GraphSystem.h"
+
+namespace ecs {
+
+class DummyAudioOut : public EcsSystem {
+public:
+    explicit DummyAudioOut(GraphSystem& g) : m_graph(g) {}
+    std::string name() const override { return "DummyAudioOut"; }
+    void setTarget(hash_t addr) { m_target = addr; }
+    void update() override;
+    void onPacket(graph::Packet&) override {}
+private:
+    GraphSystem& m_graph;
+    hash_t m_target{0};
+    uint32_t m_seq{0};
+};
+
+} // namespace ecs

--- a/src/ecs/EcsSystem.h
+++ b/src/ecs/EcsSystem.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <string>
+#include <functional>
+#include <typeinfo>
 #include "../graph/Packet.h"
+#include "../core/Hash.h"
 
 namespace ecs {
 
@@ -8,6 +11,10 @@ class EcsSystem {
 public:
     virtual ~EcsSystem() = default;
     virtual std::string name() const = 0;
+    virtual hash_t address() const {
+        return std::hash<std::string>{}(
+            std::string(typeid(*this).name()) + name());
+    }
     virtual void update() = 0;
     virtual void onPacket(graph::Packet& pkt) = 0;
 };

--- a/src/ecs/GraphSystem.h
+++ b/src/ecs/GraphSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <queue>
+#include <unordered_map>
 #include "EcsSystem.h"
 #include "../graph/PacketRecycler.h"
 
@@ -16,7 +17,7 @@ public:
     void onPacket(graph::Packet& pkt) override { enqueue(&pkt); }
 
 private:
-    std::vector<EcsSystem*> m_systems;
+    std::unordered_map<hash_t, EcsSystem*> m_systems;
     std::queue<graph::Packet*> m_packets;
 };
 

--- a/src/graph/Packet.h
+++ b/src/graph/Packet.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include "../core/Hash.h"
 
 namespace graph {
 
@@ -12,12 +13,21 @@ enum class PacketFormat {
 };
 
 struct VideoData { uint8_t dummy[256]; };
-struct AudioData { uint8_t dummy[256]; };
+constexpr std::size_t AUDIO_SAMPLES_PER_PACKET = 1024 * 2; // 1024 frames, 2 channels
+struct AudioData {
+    uint32_t sampleRate;
+    uint32_t channels;
+    uint32_t frames;
+    uint32_t seq;
+    float samples[AUDIO_SAMPLES_PER_PACKET];
+};
 struct EventData { uint8_t dummy[64]; };
 struct ModelData { uint8_t dummy[512]; };
 
 struct Packet {
     PacketFormat format{PacketFormat::Unknown};
+    hash_t address{0};
+    void* ptr{nullptr};
     union {
         VideoData video;
         AudioData audio;

--- a/src/graph/PacketRecycler.cpp
+++ b/src/graph/PacketRecycler.cpp
@@ -31,12 +31,16 @@ Packet* PacketRecycler::acquire() {
     m_free = m_free->next;
     p->next = nullptr;
     p->format = PacketFormat::Unknown;
+    p->address = 0;
+    p->ptr = nullptr;
     return p;
 }
 
 void PacketRecycler::recycle(Packet* pkt) {
     if (!pkt) return;
     pkt->next = m_free;
+    pkt->address = 0;
+    pkt->ptr = nullptr;
     m_free = pkt;
 }
 


### PR DESCRIPTION
## Summary
- Introduce hash_t type and use it for system addresses
- Add packet address and pointer fields plus fixed-size audio payload
- Route packets by address and provide dummy audio in/out systems with test app

## Testing
- `g++ -std=c++17 src/app/DummyAudioTester.cpp src/core/Program.cpp src/ecs/GraphSystem.cpp src/ecs/DummyAudioOut.cpp src/graph/PacketRecycler.cpp -I src -o DummyAudioTester && ./DummyAudioTester | head -n 3`


------
https://chatgpt.com/codex/tasks/task_e_68a649010e888327bf379ff9f71f3869