### PR TITLE
Add packet logging and debug utilities

### DIFF
--- a/src/core/Log.cpp
+++ b/src/core/Log.cpp
@@ -1,0 +1,11 @@
+#include "Log.h"
+
+namespace core {
+
+void Log::write(const std::string& line) {
+    static std::ofstream file("packets.log", std::ios::app);
+    file << line << std::endl;
+}
+
+} // namespace core
+

--- a/src/core/Log.h
+++ b/src/core/Log.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <fstream>
+#include <string>
+
+namespace core {
+
+class Log {
+public:
+    static void write(const std::string& line);
+};
+
+} // namespace core
+

--- a/src/ecs/DummyAudioIn.h
+++ b/src/ecs/DummyAudioIn.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "EcsSystem.h"
-#include <iostream>
+#include "../core/Log.h"
+#include "../graph/PacketDebug.h"
 
 namespace ecs {
 
@@ -9,10 +10,7 @@ public:
     DummyAudioIn() : EcsSystem("DummyAudioIn") {}
     void update() override {}
     void onPacket(graph::Packet& pkt) override {
-        auto& a = pkt.data.audio;
-        std::cout << "DummyAudioIn packet seq " << a.seq
-                  << " samples: " << a.samples[0] << ", " << a.samples[1]
-                  << ", " << a.samples[2] << ", " << a.samples[3] << std::endl;
+        core::Log::write(graph::toDebugString(pkt));
         pkt.address = 0; // delivered
     }
 };

--- a/src/ecs/DummyAudioOut.cpp
+++ b/src/ecs/DummyAudioOut.cpp
@@ -1,5 +1,7 @@
 #include "DummyAudioOut.h"
 #include "../graph/PacketRecycler.h"
+#include "../graph/PacketDebug.h"
+#include "../core/Log.h"
 #include <cstring>
 
 namespace ecs {
@@ -17,6 +19,7 @@ void DummyAudioOut::update() {
     for (size_t i = 0; i < graph::AUDIO_SAMPLES_PER_PACKET; ++i) {
         a.samples[i] = static_cast<float>(i % 4);
     }
+    core::Log::write(graph::toDebugString(*pkt));
     m_graph.enqueue(pkt);
 }
 

--- a/src/graph/PacketDebug.cpp
+++ b/src/graph/PacketDebug.cpp
@@ -1,0 +1,38 @@
+#include "PacketDebug.h"
+#include <sstream>
+
+namespace graph {
+
+std::string toDebugString(const Packet& pkt) {
+    std::ostringstream oss;
+    oss << "Packet addr " << pkt.address << " format ";
+    switch (pkt.format) {
+    case PacketFormat::Audio: {
+        oss << "Audio";
+        const auto& a = pkt.data.audio;
+        oss << " sampleRate=" << a.sampleRate
+            << " channels=" << a.channels
+            << " frames=" << a.frames
+            << " seq=" << a.seq
+            << " samples=[" << a.samples[0] << ", " << a.samples[1]
+            << ", " << a.samples[2] << ", " << a.samples[3] << "]";
+        break;
+    }
+    case PacketFormat::Video:
+        oss << "Video";
+        break;
+    case PacketFormat::Event:
+        oss << "Event";
+        break;
+    case PacketFormat::Model:
+        oss << "Model";
+        break;
+    default:
+        oss << "Unknown";
+        break;
+    }
+    return oss.str();
+}
+
+} // namespace graph
+

--- a/src/graph/PacketDebug.h
+++ b/src/graph/PacketDebug.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+#include "Packet.h"
+
+namespace graph {
+
+std::string toDebugString(const Packet& pkt);
+
+} // namespace graph
+


### PR DESCRIPTION
## Summary
- Implement file-based `Log` utility for writing logs in the executable directory
- Provide `PacketDebug` helper to stringify `Packet` contents
- Use new logging utilities in `DummyAudioOut` and `DummyAudioIn` to record every audio packet

## Testing
- `g++ -std=c++20 -I./src src/core/Program.cpp src/graph/PacketRecycler.cpp src/graph/PacketDebug.cpp src/core/Log.cpp src/ecs/GraphSystem.cpp src/ecs/DummyAudioOut.cpp src/app/DummyAudioTester.cpp -o DummyAudioTester`
- `./DummyAudioTester >/tmp/run_output.txt && tail -n 5 /tmp/run_output.txt`
- `head -n 5 packets.log`


------
https://chatgpt.com/codex/tasks/task_e_68a82b5342f0832786fe1af3cb71fced